### PR TITLE
Fixing memory leak in Dropdown component

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -45,8 +45,8 @@ const Dropdown = React.forwardRef<HTMLDivElement, Props>(function Dropdown(props
     document.addEventListener('click', handleClickOutside, { capture: true })
     document.addEventListener('keydown', handleEsc, { capture: true })
     return () => {
-      document.removeEventListener('click', handleClickOutside)
-      document.removeEventListener('keydown', handleEsc)
+      document.removeEventListener('click', handleClickOutside, { capture: true })
+      document.removeEventListener('keydown', handleEsc, { capture: true })
     }
   }, [isOpen])
 


### PR DESCRIPTION
Fixing memory leak in Dropdown component by matching capture options on removeEventListener